### PR TITLE
Fix missing stats visualization and histogram edge cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <!-- Third-Party Libraries (Load first) -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@1.2.1/dist/chartjs-plugin-zoom.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@sgratzl/chartjs-chart-boxplot@4.4.4/dist/chartjs-chart-boxplot.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jstat/1.9.6/jstat.min.js"></script>
 
@@ -157,6 +158,7 @@
               <option value="scatter">Scatter Plot</option>
               <option value="histogram">Histogram</option>
               <option value="qqplot">Q-Q Plot</option>
+              <option value="violin">Violin Plot</option>
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- add bounds checking to histogram builder
- implement a `visualizeStatistics` helper for statistics plots
- integrate Chart.js violin plot support

## Testing
- `node --check scripts/chartManager.js`
- `node --check scripts/statsManager.js`
- `node --check scripts/testManager.js`


------
https://chatgpt.com/codex/tasks/task_e_6845468857ac832abe2314143a47cb9c